### PR TITLE
ofx: tolerate line-terminated OFX tags in get_ofx_date_range

### DIFF
--- a/finance_dl/ofx.py
+++ b/finance_dl/ofx.py
@@ -154,8 +154,8 @@ def get_ofx_date_range(data: bytes):
         raise RuntimeError(
             'More than one dtstart or dtend found in OFX document: %s' %
             (data, ))
-    dtstart = parse_ofx_time(dtstart_nodes[0].text)
-    dtend = parse_ofx_time(dtend_nodes[0].text)
+    dtstart = parse_ofx_time(dtstart_nodes[0].text.split("\r\n")[0])
+    dtend = parse_ofx_time(dtend_nodes[0].text.split("\r\n")[0])
     return dtstart, dtend
 
 


### PR DESCRIPTION
For example

```
        <INVTRANLIST>
          <DTSTART>20190301
          <DTEND>20190303120000
        </INVTRANLIST>
```