### PR TITLE
Support colons in account names.

### DIFF
--- a/finance_dl/ofx.py
+++ b/finance_dl/ofx.py
@@ -126,12 +126,15 @@ warnings.filterwarnings('ignore', message='split()', module='re')
 
 logger = logging.getLogger('ofx')
 
-def check_path_component(name: str):
-    if name == '.' or name == '..':
-        return False
-    if re.match(r'^[a-z0-9A-Z.\-:]+$', name):
-        return True
-    return False
+def sanitize_account_name(account_name: str):
+    """Replaces any sequence of invalid characters in the account name with a dash.
+
+    Returns the sanitized account name.
+    """
+    if account_name == '.' or account_name == '..':
+        raise ValueError('Invalid account name: %s' % account_name)
+
+    return re.sub('[^a-z0-9A-Z.-]+', '-', account_name)
 
 
 def download_account_data_starting_from(account: ofxclient.account.Account,
@@ -300,8 +303,9 @@ def save_all_account_data(inst: ofxclient.institution.Institution,
     """
     accounts = inst.accounts()
     for a in accounts:
-        name = a.number
-        if not check_path_component(name):
+        try:
+            name = sanitize_account_name(a.number)
+        except ValueError:
             logger.warning('Account number is invalid path component: %r',
                            name)
             continue

--- a/finance_dl/ofx.py
+++ b/finance_dl/ofx.py
@@ -129,7 +129,7 @@ logger = logging.getLogger('ofx')
 def check_path_component(name: str):
     if name == '.' or name == '..':
         return False
-    if re.match(r'^[a-z0-9A-Z.\-]+$', name):
+    if re.match(r'^[a-z0-9A-Z.\-:]+$', name):
         return True
     return False
 

--- a/setup.py
+++ b/setup.py
@@ -34,4 +34,7 @@ setup(
         'atomicwrites>=1.3.0',
         'jsonschema',
     ],
+    tests_require=[
+        'pytest',
+    ]
 )

--- a/tests/test_ofx.py
+++ b/tests/test_ofx.py
@@ -1,0 +1,23 @@
+import pytest
+
+from finance_dl.ofx import sanitize_account_name
+
+
+def test_sanitize_account_name_disallows_dot():
+    with pytest.raises(ValueError):
+        sanitize_account_name('.')
+
+
+def test_sanitize_account_name_disallows_double_dot():
+    with pytest.raises(ValueError):
+        sanitize_account_name('..')
+
+
+def test_sanitize_account_name_passes_through_standard_characters():
+    account_name = 'abc1234.5678-90-XYZ'
+
+    assert sanitize_account_name(account_name) == account_name
+
+
+def test_sanitize_account_name_replaces_invalid_characters():
+    assert sanitize_account_name('1234$!5678:XYZ') == '1234-5678-XYZ'

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,5 @@ deps =
      mypy
 
 commands =
+     pytest .
      mypy finance_dl


### PR DESCRIPTION
My bank uses colons in account names to denote sub-accounts (checking, savings, etc.). Example: "1234567L:0001" or "1234567S:0009". So this proposed change supports such account names in finance-dl. 

Testing done: Ran this modified finance-dl against my bank via OFX, and observed that finance-dl created the expected filesystem hierarchy complete with account names containing colons:

```bash
$ tree
.
├── 1234567L:0001
│   ├── 6789...--...0123.ofx
...
```

I don't see a downside to supporting this, except perhaps for compatibility with (non-Cygwin) Windows systems. Which might not be supported by finance-dl anyway? Let me know if there are any other downsides/dealbreakers I'm not seeing. Thanks!