### PR TITLE
Don't error if OFX account has zero transactions (#18).

### DIFF
--- a/finance_dl/ofx.py
+++ b/finance_dl/ofx.py
@@ -216,7 +216,8 @@ def save_single_account_data(
         returning at least 30 days of transactions per request.
     :param min_start_date: If no existing files are present in `output_dir`, a
         binary search is done starting from this date to determine the first
-        date for which the server returns a valid response.
+        date for which the server returns a valid response. If this search turns
+        up zero transactions, then nothing is saved for this account.
     """
 
     # Minimum number of days that the server is expected to give data for.
@@ -258,8 +259,13 @@ def save_single_account_data(
         date_ranges.sort()
 
     if len(date_ranges) == 0:
-        date_range, data = get_earliest_data(account,
-                                             start_date=min_start_date)
+        try:
+            date_range, data = get_earliest_data(account,
+                                                 start_date=min_start_date)
+        except RuntimeError as error:
+            logger.warning(error)
+            return
+
         save_data(date_range, data)
 
     def retrieve_more():


### PR DESCRIPTION
As discussed in https://github.com/jbms/finance-dl/issues/18, this change downgrades a fatal error into a mere warning upon finding an OFX account with no transactions. Instead of the previously reported traceback, I now get the following:

```console
...
[0/1] institution [50s elapsed] 2019-06-05 05:15:33,649 ofx.py:266 [WARNING] Failed to retrieve any data for account: 12345678
[1/1] institution [50s elapsed] SUCCESS
```