### PR TITLE
Adjust for new split Amazon login form

### DIFF
--- a/finance_dl/amazon.py
+++ b/finance_dl/amazon.py
@@ -121,6 +121,7 @@ class Scraper(scrape_lib.Scraper):
             lambda: self.find_visible_elements(By.XPATH, '//input[@type="email"]')
         )
         username.send_keys(self.credentials['username'])
+        username.send_keys(Keys.ENTER)
 
         logger.info('Looking for password link')
         (password, ), = self.wait_and_return(


### PR DESCRIPTION
Amazon login now requires form submit between entering username and
entering password. Checked on both .com and .co.uk. Verified this fix
works to now allow the scraper to log me in to Amazon.