### PR TITLE
Fix off by one error.

### DIFF
--- a/finance_dl/amazon.py
+++ b/finance_dl/amazon.py
@@ -224,7 +224,7 @@ class Scraper(scrape_lib.Scraper):
                     continue
                 logger.info('Retrieving order group: %r', option_text)
                 with self.wait_for_page_load():
-                    order_select.select_by_index(order_select_index)
+                    order_select.select_by_index(order_select_index-1)
                 get_invoice_urls()
 
         if regular:


### PR DESCRIPTION
The Amazon downloader sometimes gets stuck on the first Orders page. It tries to go to "last 30 days" option of the drop-down menu, but it actually stays on the "past 3 months". Furthermore, when downloading all orders, it throws an index out of bounds error on the very last option of the drop-down list. An inspection of the code suggests this is because the counter starts at 0 but gets increased too early on line 219.