### PR TITLE
Adjust to new link text on Amazon orders page.

### DIFF
--- a/finance_dl/amazon.py
+++ b/finance_dl/amazon.py
@@ -169,7 +169,7 @@ class Scraper(scrape_lib.Scraper):
 
                 order_ids = set()
                 for invoice_link in invoices:
-                    if invoice_link.text != "Invoice":
+                    if "nvoice" not in invoice_link.text:
                         continue
                     href = invoice_link.get_attribute('href')
                     m = re.match('.*[&?]orderID=((?:D)?[0-9\\-]+)(?:&.*)?$', href)


### PR DESCRIPTION
Amazon changed the invoice link text on the orders page from "Invoice" to "View invoice"; this fixes the Amazon downloader to account for that change (and work with either text).

It would also be an option to switch to looking at the href of the link to distinguish "view order details" from "view invoice" link. Perhaps the URL href is less likely to change than the link text?