### PR TITLE
bug(healthequity): eliminate duplicate tax year from txn descriptions

### DIFF
--- a/finance_dl/healthequity.py
+++ b/finance_dl/healthequity.py
@@ -163,6 +163,8 @@ def write_transactions(raw_transactions_data, path):
         row_values = dict(zip(headers, cells))
         # Sanitize whitespace in description
         row_values['Transaction'] = ' '.join(row_values['Transaction'].split())
+        # Remove duplicate tax year in description
+        row_values['Transaction'] = re.sub(r'(\(Tax year: \d+\)) *\1', r'\1', row_values['Transaction'])
         row_values['Cash Balance'] = row_values.pop('HSA Cash Balance')
 
         # Sanitize date_str


### PR DESCRIPTION
Lately the HealthEquity transaction download has entries like "Employee
Contribution (Tax year: 2019) (Tax year: 2019)", where it used to just say
"Employee Contribution (Tax year: 2019)" — the change causes erroneous
duplicate transactions to be downloaded. This commit fixes that.