### PR TITLE
pass overwrite to atomic_write

### DIFF
--- a/finance_dl/amazon.py
+++ b/finance_dl/amazon.py
@@ -283,7 +283,7 @@ class Scraper(scrape_lib.Scraper):
                                  % (order_id, ))
             with atomic_write(
                     invoice_path, mode='w', encoding='utf-8',
-                    newline='\n') as f:
+                    newline='\n', overwrite=True) as f:
                 # Write with Unicode Byte Order Mark to ensure content will be properly interpreted as UTF-8
                 f.write('\ufeff' + page_source)
             logger.info('  Wrote %s', invoice_path)

--- a/finance_dl/anthem.py
+++ b/finance_dl/anthem.py
@@ -140,7 +140,7 @@ class Scraper(scrape_lib.Scraper):
             if not os.path.exists(json_path):
                 with atomic_write(
                         json_path, mode='w', encoding='utf-8',
-                        newline='\n') as f:
+                        newline='\n', overwrite=True) as f:
                     f.write(json.dumps(claim, indent='  ').strip() + '\n')
             if not os.path.exists(pdf_path):
                 if not claim['eobLinkUrl'].startswith('https:/'): continue
@@ -149,7 +149,7 @@ class Scraper(scrape_lib.Scraper):
             logger.info('Downloading EOB %d/%d', i + 1, len(downloads_needed))
             self.driver.get(url)
             download_result, = self.wait_and_return(self.get_downloaded_file)
-            with atomic_write(pdf_path, mode='wb') as f:
+            with atomic_write(pdf_path, mode='wb', overwrite=True) as f:
                 f.write(download_result[1])
 
     def run(self):

--- a/finance_dl/ebmud.py
+++ b/finance_dl/ebmud.py
@@ -128,7 +128,7 @@ class Scraper(scrape_lib.Scraper):
             logger.info('Downloading %s', statement_path)
             self.click(row.find_element_by_tag_name('a'))
             download_result, = self.wait_and_return(self.get_downloaded_file)
-            with atomic_write(statement_path, mode='wb') as f:
+            with atomic_write(statement_path, mode='wb', overwrite=True) as f:
                 f.write(download_result[1])
             logger.info('Wrote %s', statement_path)
 

--- a/finance_dl/google_purchases.py
+++ b/finance_dl/google_purchases.py
@@ -110,7 +110,8 @@ class Scraper(google_takeout.Scraper):
                 self.driver.get(url)
             content = self.driver.page_source
             with atomic_write(
-                    html_path, mode='w', encoding='utf-8', newline='\n') as f:
+                    html_path, mode='w', encoding='utf-8', newline='\n',
+                    overwrite=True) as f:
                 # Write with Unicode Byte Order Mark to ensure content will be properly interpreted as UTF-8
                 f.write('\ufeff' + content)
             logger.info('Write details %d/%d: %s', i, len(need_to_fetch), html_path)
@@ -133,7 +134,7 @@ class Scraper(google_takeout.Scraper):
             json_path = os.path.join(self.output_directory,
                                      'order_' + order_id + '.json')
             if not os.path.exists(json_path):
-                with atomic_write(json_path, mode='wb') as f:
+                with atomic_write(json_path, mode='wb', overwrite=True) as f:
                     f.write(takeout_zip.read(name))
             html_path = os.path.join(self.output_directory, order_id + '.html')
             if os.path.exists(html_path):

--- a/finance_dl/ofx.py
+++ b/finance_dl/ofx.py
@@ -268,7 +268,7 @@ def save_single_account_data(
         logger.info('Received data %s -- %s', date_range[0], date_range[1])
         filename = ('%s-%s--%d.ofx' % (date_range[0].strftime(date_format),
                                        date_range[1].strftime(date_format), t))
-        with atomic_write(os.path.join(output_dir, filename), mode='wb') as f:
+        with atomic_write(os.path.join(output_dir, filename), mode='wb', overwrite=True) as f:
             f.write(data)
         date_ranges.append((date_range[0].date(), date_range[1].date()))
         date_ranges.sort()

--- a/finance_dl/paypal.py
+++ b/finance_dl/paypal.py
@@ -206,7 +206,7 @@ class Scraper(scrape_lib.Scraper):
                     r = self.driver.request('GET', invoice_url)
                     r.raise_for_status()
                     data = r.content
-                    with atomic_write(pdf_path, mode='wb') as f:
+                    with atomic_write(pdf_path, mode='wb', overwrite=True) as f:
                         f.write(data)
                 invoice_json_path = output_prefix + '.invoice.json'
                 if not os.path.exists(invoice_json_path):
@@ -214,7 +214,8 @@ class Scraper(scrape_lib.Scraper):
                             invoice_json_path,
                             mode='w',
                             encoding='utf-8',
-                            newline='\n') as f:
+                            newline='\n',
+                            overwrite=True) as f:
                         f.write(json.dumps(transaction, indent='  '))
                 continue
             details_url = (
@@ -231,7 +232,7 @@ class Scraper(scrape_lib.Scraper):
                 html_resp.raise_for_status()
                 with atomic_write(
                         html_path, mode='w', encoding='utf-8',
-                        newline='\n') as f:
+                        newline='\n', overwrite=True) as f:
                     # Write with Unicode Byte Order Mark to ensure content will be properly interpreted as UTF-8
                     f.write('\ufeff' + html_resp.text)
             if not os.path.exists(json_path):
@@ -240,7 +241,7 @@ class Scraper(scrape_lib.Scraper):
                 json_resp.raise_for_status()
                 j = json_resp.json()
                 jsonschema.validate(j, transaction_details_schema)
-                with atomic_write(json_path, mode='wb') as f:
+                with atomic_write(json_path, mode='wb', overwrite=True) as f:
                     f.write(
                         json.dumps(j['data']['details'], indent='  ').encode())
 

--- a/finance_dl/ultipro_google.py
+++ b/finance_dl/ultipro_google.py
@@ -160,7 +160,7 @@ class Scraper(scrape_lib.Scraper):
                 output_name = '%s.statement-%s.pdf' % (
                     pay_date.strftime('%Y-%m-%d'), document_number)
                 output_path = os.path.join(self.output_directory, output_name)
-                with atomic_write(output_path, mode='wb') as f:
+                with atomic_write(output_path, mode='wb', overwrite=True) as f:
                     f.write(data)
                 downloaded_statements.add((pay_date, document_number))
                 return True

--- a/finance_dl/waveapps.py
+++ b/finance_dl/waveapps.py
@@ -174,14 +174,15 @@ class WaveScraper(object):
                     r = requests.get(image_url)
                     r.raise_for_status()
                     data = r.content
-                    with atomic_write(image_path, mode='wb') as f:
+                    with atomic_write(image_path, mode='wb', overwrite=True) as f:
                         f.write(data)
             with atomic_write(
                     json_path,
                     mode='w',
                     overwrite=True,
                     encoding='utf-8',
-                    newline='\n') as f:
+                    newline='\n',
+                    overwrite=True) as f:
                 json.dump(receipt, f, sort_keys=True, indent='  ')
 
     def run(self):


### PR DESCRIPTION
I need this because I keep my finance-dl data in Google Drive mounted with
google-drive-ocamlfuse, and it doesn't support the operation atomic_write does
without it. (With overwrite=True, atomicwrites does a rename; otherwise it
does a link followed by an unlink. google-drive-fuse supports rename just
fine, but not hard links.)

The real solution is probably to fix atomicwrites to properly support all
filesystems that don't support links instead of just Windows, but this is less work.