### PR TITLE
ofx: try actual specified lower bound before binary searching to find earliest available start date

### DIFF
--- a/finance_dl/ofx.py
+++ b/finance_dl/ofx.py
@@ -178,6 +178,12 @@ def get_earliest_data(account, start_date, slowdown = False):
 
     Returns ((startdate, enddate), data).
     """
+    # First try the actual start_date; if it works, no binary search is needed
+    data = download_account_data_starting_from(account, start_date)
+    date_range = get_ofx_date_range(data)
+    if date_range is not None:
+        return date_range, data
+
     logger.info(
         'Binary searching to find earliest data available for account %s.',
         account.number)


### PR DESCRIPTION
The ofx source tries to guess when data for an account begins. It has the user
specify a minimum start date as an anchor, and then uses binary search to find
the earliest date since then which generates a nonempty response from the
institution.

If the institution actually has data from the minimum start date, this results
in a rather silly search—and, in fact, the binary search as implemented never
tries the lower bound of the range at all (the interval being searched is open
at both ends), so if a user specifies the actual first day for which they have
data as min_start_date, finance-dl would always miss that first day. Given
that the user knowing when their data starts is at least a plausible case, we
should try it before resorting to cleverness; this change makes us do so.