### PR TITLE
amazon: always click Your Orders link

### DIFF
--- a/finance_dl/amazon.py
+++ b/finance_dl/amazon.py
@@ -240,15 +240,15 @@ class Scraper(scrape_lib.Scraper):
                         order_select.select_by_index(order_select_index - 1)
                 get_invoice_urls()
 
-        if regular:
-            orders_text = "Your Orders" if self.amazon_domain == Domain.CO_UK else "Orders"
-            # on co.uk, orders link is hidden behind the menu, hence not directly clickable
-            (orders_link,), = self.wait_and_return(
-                lambda: self.find_elements_by_descendant_text_match('. = "{}"'.format(orders_text), 'a', only_displayed=False)
-            )
-            link = orders_link.get_attribute('href')
-            scrape_lib.retry(lambda: self.driver.get(link), retry_delay=2)
+        orders_text = "Your Orders" if self.amazon_domain == Domain.CO_UK else "Orders"
+        # on co.uk, orders link is hidden behind the menu, hence not directly clickable
+        (orders_link,), = self.wait_and_return(
+            lambda: self.find_elements_by_descendant_text_match('. = "{}"'.format(orders_text), 'a', only_displayed=False)
+        )
+        link = orders_link.get_attribute('href')
+        scrape_lib.retry(lambda: self.driver.get(link), retry_delay=2)
 
+        if regular:
             retrieve_all_order_groups()
 
         if digital:


### PR DESCRIPTION
The amazon source has two config parameters `regular` and `digital` which
control fetching of invoices for regular and digital orders respectively. When
`regular` was false, we were not clicking the Your Orders link on the landing
page; this is required when fetching digital orders (because the Digital
Orders link appears on the Your Orders page but not the front page).

This change makes the amazon source always click the Your Orders link before
retrieving invoices, even if only retrieving invoices for digital orders.