### PR TITLE
Fix Gemini ticker API error with GUSD symbol

### DIFF
--- a/finance_dl/gemini.py
+++ b/finance_dl/gemini.py
@@ -187,8 +187,9 @@ def get_balances_and_prices(requester, api_key, api_secret, data_dir):
     logger.info(f"Got balances. Found {len(balances)} currencies.")
 
     # Prices
-    tickers = [b['currency'] + "USD" for b in balances if b['currency'] != 'USD']
+    tickers = [b['currency'] + "USD" for b in balances if b['currency'] != 'USD' and b['currency'] != 'GUSD']
     prices = {}
+    prices['GUSD'] = 1
     for t in tickers:
         obj = requester.make_request(TICKERS_URL+"/"+t.lower(), None, get = True)
         price = (float(obj['ask']) + float(obj['bid']))/2


### PR DESCRIPTION
Apparently the `GUSDUSD` symbol isn't valid for the `/v1/ticker` endpoint, which I guess makes sense since it's always a 1:1 exchange on Gemini. I kept running into this error while trying to pull transactions/transfers via the CLI.

I was able to find the issue and make a small patch, which allowed me to execute all the way through and seemed to get the right data.

I don't actually know Python, so I'm not sure if this would cause unintended problems elsewhere, but figured I'd make a PR anyways since its a very small edit.
