### PR TITLE
Fix venmo transactions for crypto-holding accounts

### DIFF
--- a/finance_dl/venmo.py
+++ b/finance_dl/venmo.py
@@ -222,7 +222,11 @@ class Scraper(scrape_lib.Scraper):
         # Make sure rows are valid transactions with a date
         good_rows = []
         for r in rows:
-            if 'Datetime' not in r or r['Datetime'] != '':
+            if not r['ID'].isdigit():
+                logging.info('Invalid ID in row: {}'.format(r))
+                continue
+
+            if r['Datetime'] != '':
                 good_rows.append(r)
             else:
                 logging.info('Invalid date in row: {}'.format(r))


### PR DESCRIPTION
Newer csv downloads include crypto details as well "Available beginning" and "Available ending" balances. This PR seeks to ignore those rows.

Why? The crypto transactions do not follow the csv format specified for regular Venmo transactions (like payment or standard transfers). Handling these transactions will require special parsing to process.