### PR TITLE
chore: stop using removed webdriver find_by methods

### DIFF
--- a/finance_dl/amazon.py
+++ b/finance_dl/amazon.py
@@ -352,7 +352,7 @@ class Scraper(scrape_lib.Scraper):
                             By.XPATH, '//a[contains(@href, "orderID=")]')
                     else:
                         # order summary link is hidden in submenu for each order
-                        elements = self.driver.find_elements_by_xpath(
+                        elements = self.driver.find_elements(By.XPATH, 
                             '//a[@class="a-popover-trigger a-declarative"]')
                         return [a for a in elements if a.text == self.domain.invoice]
                 
@@ -389,7 +389,7 @@ class Scraper(scrape_lib.Scraper):
                         # submenu containing order summary takes some time to load after click
                         # search for order summary link and compare order_id
                         # repeat until order_id is different to last order_id
-                        summary_links = self.driver.find_elements_by_link_text(
+                        summary_links = self.driver.find_elements(By.LINK_TEXT, 
                             self.domain.order_summary)
                         if summary_links:
                             href = summary_links[0].get_attribute('href')

--- a/finance_dl/comcast.py
+++ b/finance_dl/comcast.py
@@ -150,7 +150,7 @@ class Scraper(scrape_lib.Scraper):
                 pass
         bills_link = get_bills_link()
 
-        self.driver.find_element_by_tag_name('body').send_keys(Keys.ESCAPE)
+        self.driver.find_element(By.TAG_NAME, 'body').send_keys(Keys.ESCAPE)
         bills_link.click()
 
         def get_links():
@@ -168,7 +168,7 @@ class Scraper(scrape_lib.Scraper):
             cur_el = link
             bill_date = None
             while True:
-                parent = cur_el.find_element_by_xpath('..')
+                parent = cur_el.find_element(By.XPATH, '..')
                 if parent == cur_el:
                     break
                 try:

--- a/finance_dl/discover.py
+++ b/finance_dl/discover.py
@@ -57,6 +57,7 @@ import logging
 import os
 import shutil
 from selenium.common.exceptions import NoSuchElementException, TimeoutException
+from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 
 from . import scrape_lib
@@ -85,11 +86,11 @@ class Scraper(scrape_lib.Scraper):
         check_url(self.driver.current_url)
 
     def find_account_last4(self):
-        return self.driver.find_element_by_xpath(XPATH_OF_LAST_FOUR_DIGITS).text
+        return self.driver.find_element(By.XPATH, XPATH_OF_LAST_FOUR_DIGITS).text
 
     def login(self):
         try:
-            account = self.driver.find_element_by_xpath(XPATH_OF_LAST_FOUR_DIGITS)
+            account = self.driver.find_element(By.XPATH, XPATH_OF_LAST_FOUR_DIGITS)
             logger.info("Already logged in")
         except NoSuchElementException:
             logger.info('Initiating log in')

--- a/finance_dl/scrape_lib.py
+++ b/finance_dl/scrape_lib.py
@@ -23,12 +23,12 @@ def all_conditions(*conditions):
 
 
 def extract_table_data(table, header_names, single_header=False):
-    rows = table.find_elements_by_xpath('thead/tr | tbody/tr | tr')
+    rows = table.find_elements(By.XPATH, 'thead/tr | tbody/tr | tr')
     headers = []
     seen_data = False
     data = []
     for row in rows:
-        cell_elements = row.find_elements_by_xpath('th | td')
+        cell_elements = row.find_elements(By.XPATH, 'th | td')
         cell_values = [x.text.strip() for x in cell_elements]
         is_header_values = [x in header_names for x in cell_values if x]
         if len(is_header_values) == 0:
@@ -217,7 +217,7 @@ class Scraper(object):
     # See http://www.obeythetestinggoat.com/how-to-get-selenium-to-wait-for-page-load-after-a-click.html
     @contextlib.contextmanager
     def wait_for_page_load(self, timeout=30):
-        old_page = self.driver.find_element_by_tag_name('html')
+        old_page = self.driver.find_element(By.TAG_NAME, 'html')
         yield
         WebDriverWait(self.driver, timeout).until(
             expected_conditions.staleness_of(old_page),
@@ -355,7 +355,7 @@ class Scraper(object):
 
     def find_elements_by_descendant_partial_text(self, text, element_name,
                                                  only_displayed=False):
-        all_elements = self.driver.find_elements_by_xpath(
+        all_elements = self.driver.find_elements(By.XPATH, 
             "//text()[contains(.,%r)]/ancestor::*[self::%s][1]" %
             (text, element_name))
         if only_displayed:
@@ -364,7 +364,7 @@ class Scraper(object):
 
     def find_elements_by_descendant_text_match(self, text_match, element_name,
                                                only_displayed=False):
-        all_elements = self.driver.find_elements_by_xpath(
+        all_elements = self.driver.find_elements(By.XPATH, 
             "//text()[%s]/ancestor::*[self::%s][1]" % (text_match,
                                                        element_name))
         if only_displayed:
@@ -372,7 +372,7 @@ class Scraper(object):
         return all_elements
 
     def find_visible_elements_by_partial_text(self, text, element_name):
-        all_elements = self.driver.find_elements_by_xpath(
+        all_elements = self.driver.find_elements(By.XPATH, 
             "//%s[contains(.,%r)]" % (element_name, text))
         return [x for x in all_elements if is_displayed(x)]
 

--- a/finance_dl/usbank.py
+++ b/finance_dl/usbank.py
@@ -146,7 +146,7 @@ class Scraper(scrape_lib.Scraper):
     def find_account_link_in_any_frame(self):
         for frame in self.for_each_frame():
             try:
-                return self.driver.find_element_by_partial_link_text(self.account_name)
+                return self.driver.find_element(By.PARTIAL_LINK_TEXT, self.account_name)
             except:
                 pass
         raise NoSuchElementException()
@@ -155,7 +155,7 @@ class Scraper(scrape_lib.Scraper):
     def find_download_page_in_any_frame(self):
         for frame in self.for_each_frame():
             try:
-                return self.driver.find_element_by_partial_link_text("Download Transactions")
+                return self.driver.find_element(By.PARTIAL_LINK_TEXT, "Download Transactions")
             except:
                 pass
         raise NoSuchElementException()
@@ -164,8 +164,8 @@ class Scraper(scrape_lib.Scraper):
     def find_date_fields(self):
         for frame in self.for_each_frame():
             try:
-                fromDate = self.driver.find_element_by_id("FromDateInput")
-                toDate = self.driver.find_element_by_id("ToDateInput")
+                fromDate = self.driver.find_element(By.ID, "FromDateInput")
+                toDate = self.driver.find_element(By.ID, "ToDateInput")
                 return (fromDate, toDate)
             except:
                 pass
@@ -175,7 +175,7 @@ class Scraper(scrape_lib.Scraper):
     def find_download_link(self):
         for frame in self.for_each_frame():
             try:
-                return self.driver.find_elements_by_id("DTLLink")[0]
+                return self.driver.find_elements(By.ID, "DTLLink")[0]
             except:
                 pass
         raise NoSuchElementException()


### PR DESCRIPTION
Selenium removed the `find_element{,s}_by_$SELECTOR` methods
after a long deprecation period in 4.3.0.  This change removes all uses of
those methods in favor of `find_element{,s}(By.SELECTOR, ...)`.