### PR TITLE
[Paypal] handle case gracefully when only JSON can be extracted but no HTML

### DIFF
--- a/finance_dl/waveapps.py
+++ b/finance_dl/waveapps.py
@@ -75,7 +75,7 @@ Example:
 
 """
 
-from typing import List, Any
+from typing import List, Any, Optional
 import contextlib
 import logging
 import json
@@ -154,7 +154,7 @@ class WaveScraper(object):
         receipts.extend(cur_list)
         return receipts
 
-    def save_receipts(self, receipts: List[Any], output_directory: str = None):
+    def save_receipts(self, receipts: List[Any], output_directory: Optional[str] = None):
         if not output_directory:
             output_directory = self.output_directory
         if not os.path.exists(output_directory):


### PR DESCRIPTION
I experienced a case today where no HTML could be extracted from a Paypal transaction. It was a reimbursement of a previous purchase. This resulted in termination of the script.

I tried to scrape the URLs manually. No luck with the HTML URL but the JSON of the transaction could be retrieved successfully.

I modified the code to gracefully fail the HTML download in case the JSON download was successful. The resulting `.html` file just shows the error. I changed the order, so the JSON is requested before the HTML.