### PR TITLE
fix: ignore `.com.google.Chrome.*` files in download dir

### DIFF
--- a/finance_dl/scrape_lib.py
+++ b/finance_dl/scrape_lib.py
@@ -195,7 +195,7 @@ class Scraper(object):
         partial_names = []
         other_names = []
         for name in names:
-            if name.endswith('.part') or name.endswith('.crdownload'):
+            if name.endswith('.part') or name.endswith('.crdownload') or name.startswith('.com.google.Chrome'):
                 partial_names.append(name)
             else:
                 other_names.append(name)


### PR DESCRIPTION
seems these now get written during in-progress downloads, confusing scrape_lib's detection of the download being finished and resulting in truncated downloads.