### PR TITLE
PayPal: skip logging in if already logged in

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,28 +39,3 @@ jobs:
         path: |
           dist/*.whl
           dist/*.tar.gz
-
-  python-publish-package:
-    # Only publish package on push to tag or default branch.
-    if: ${{ github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/master') }}
-    runs-on: ubuntu-latest
-    needs:
-      - tox
-    steps:
-    - uses: actions/download-artifact@v4.1.7
-      with:
-        name: python-packages
-        path: dist
-    - name: Publish to PyPI (test server)
-      uses: pypa/gh-action-pypi-publish@54b39fb9371c0b3a6f9f14bb8a67394defc7a806 # 2020-09-25
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_test_token }}
-        repository_url: https://test.pypi.org/legacy/
-      if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
-    - name: Publish to PyPI (main server)
-      uses: pypa/gh-action-pypi-publish@54b39fb9371c0b3a6f9f14bb8a67394defc7a806 # 2020-09-25
-      with:
-        user: __token__
-        password: ${{ secrets.pypi_token }}
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
Fixes crash that occurs when already logged in.