### PR TITLE
[paypal] fix CSRF token retrieval

### DIFF
--- a/finance_dl/paypal.py
+++ b/finance_dl/paypal.py
@@ -188,10 +188,11 @@ class Scraper(scrape_lib.Scraper):
         logging.info('Getting CSRF token')
         self.driver.get('https://www.paypal.com/myaccount/transactions/')
         # Get CSRF token
-        body_element, = self.wait_and_locate((By.ID, "__APP_DATA__"))
-        data = base64.b64decode(body_element.get_attribute("innerHTML"))
+        body_element, = self.wait_and_locate((By.ID, "__react_data__"))
+        data = base64.b64decode(body_element.get_attribute("data"))
         attribute_object = json.loads(data)
         self.csrf_token = attribute_object["_csrf"]
+        logging.info('CSRF token retrieved')
         return self.csrf_token
 
     def get_transaction_list(self):


### PR DESCRIPTION
Paypal once again changed how they expose the CSRF token... at least we had this already some time ago.